### PR TITLE
Implémentation Cone

### DIFF
--- a/sources/Plugins/Primitives/Cones/CMakeLists.txt
+++ b/sources/Plugins/Primitives/Cones/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.10)
+project(ConePlugin)
+
+set(CMAKE_CXX_STANDARD 20)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBCONFIG++ REQUIRED IMPORTED_TARGET libconfig++)
+
+set(SOURCES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+include_directories(${SOURCES_DIR}/Shared/Geometry/Vec3)
+include_directories(${SOURCES_DIR}/Shared/Geometry/Vec2)
+include_directories(${SOURCES_DIR}/Shared/Geometry/Ray)
+include_directories(${SOURCES_DIR}/Shared/)
+include_directories(${SOURCES_DIR}/Shared/Materials)
+include_directories(${SOURCES_DIR}/Entities)
+include_directories(${SOURCES_DIR}/Shared/Utils/Errors)
+include_directories(${SOURCES_DIR}/Entities/Primitives)
+include_directories(${SOURCES_DIR}/Shared/Utils/Errors)
+include_directories(${SOURCES_DIR}/Plugins/Primitives)
+include_directories(${SOURCES_DIR}/Plugins/Decorator)
+include_directories(${SOURCES_DIR}/Plugins/Light)
+
+
+set(SOURCE_FILES
+        Cone.cpp
+        Cone.hpp
+        ConesEntryPoint.cpp
+        ${SOURCES_DIR}/Plugins/AEntity.cpp)
+
+add_library(ConePlugin SHARED ${SOURCE_FILES})
+target_include_directories(ConePlugin PRIVATE ${LIBCONFIG++_INCLUDE_DIRS})
+
+target_link_libraries(ConePlugin PUBLIC PkgConfig::LIBCONFIG++ raytracer_lib)
+

--- a/sources/Plugins/Primitives/Cones/Cone.cpp
+++ b/sources/Plugins/Primitives/Cones/Cone.cpp
@@ -1,0 +1,57 @@
+/*
+** EPITECH PROJECT, 2023
+** raytracer
+** File description:
+** Cone
+*/
+
+#include <cmath>
+#include <iostream>
+#include "Cone.hpp"
+
+
+RayTracer::Plugins::Primitives::Cone::Cone(const RayTracer::Shared::Vec3& position, float radius, const RayTracer::Shared::Vec3& color)
+: APrimitive(position, RayTracer::Shared::Vec3()), _radius(radius), _color(color)
+{
+    std::cout << "Cone created" << std::endl;
+}
+
+void RayTracer::Plugins::Primitives::Cone::scale(float scale) {
+    _radius *= scale;
+}
+
+std::optional<std::unique_ptr<RayTracer::Shared::Intersection>> RayTracer::Plugins::Primitives::Cone::intersect(const RayTracer::Shared::Ray &ray, float& t) const
+{
+    float a = ray.getDirection().x * ray.getDirection().x + ray.getDirection().z * ray.getDirection().z - ray.getDirection().y * ray.getDirection().y;
+    float b = 2 * ((ray.getDirection().x * (ray.getOrigin().x - _position.x) + ray.getDirection().z * (ray.getOrigin().z - _position.z)) - ray.getDirection().y * (ray.getOrigin().y - _position.y));
+    float c = (ray.getOrigin().x - _position.x) * (ray.getOrigin().x - _position.x) + (ray.getOrigin().z - _position.z) * (ray.getOrigin().z - _position.z) - (ray.getOrigin().y - _position.y) * (ray.getOrigin().y - _position.y);
+
+    float discriminant = b * b - 4 * a * c;
+
+    if (discriminant < 0) {
+        return std::nullopt;
+    }
+
+    float t0 = (-b - sqrt(discriminant)) / (2 * a);
+    float t1 = (-b + sqrt(discriminant)) / (2 * a);
+
+    if (t0 > t1) std::swap(t0, t1);
+
+    if (t0 < 1e-4) {
+        t0 = t1;
+        if (t0 < 1e-4) return std::nullopt;
+    }
+
+    t = t0;
+    RayTracer::Shared::Vec3 hitPoint = ray.pointAt(t);
+    RayTracer::Shared::Vec3 normal = (hitPoint - _position);
+    normal.y = -normal.y;
+
+    auto intersection = std::make_unique<RayTracer::Shared::Intersection>();
+    intersection->hit = true;
+    intersection->t = t;
+    intersection->point = hitPoint;
+    intersection->normal = normal.normalize();
+
+    return std::optional<std::unique_ptr<RayTracer::Shared::Intersection>>(std::move(intersection));
+}

--- a/sources/Plugins/Primitives/Cones/Cone.hpp
+++ b/sources/Plugins/Primitives/Cones/Cone.hpp
@@ -1,0 +1,35 @@
+/*
+** EPITECH PROJECT, 2023
+** raytracer
+** File description:
+** Cone
+*/
+
+#pragma once
+
+#include <optional>
+#include "AEntity.hpp"
+#include "IEntity.hpp"
+#include "APrimitive.hpp"
+#include "Ray.hpp"
+
+namespace RayTracer {
+    namespace Plugins {
+        namespace Primitives {
+
+            class Cone : public RayTracer::Plugins::Primitives::APrimitive {
+            public:
+                Cone(const RayTracer::Shared::Vec3& position, float radius, const RayTracer::Shared::Vec3& color);
+
+                void scale(float scale) override;
+                std::optional<std::unique_ptr<RayTracer::Shared::Intersection>> intersect(const RayTracer::Shared::Ray& ray, float& t) const override;
+
+            private:
+                float _radius;
+                RayTracer::Shared::Vec3 _color;
+            };
+
+        } // Primitives
+    } // Plugins
+} // Raytracer
+

--- a/sources/Plugins/Primitives/Cones/ConesEntryPoint.cpp
+++ b/sources/Plugins/Primitives/Cones/ConesEntryPoint.cpp
@@ -1,0 +1,78 @@
+/*
+** EPITECH PROJECT, 2023
+** raytracer
+** File description:
+** ConesEntryPoint
+*/
+
+#include <memory>
+#include <libconfig.h++>
+#include <iostream>
+#include "Cone.hpp"
+#include "Vec3.hpp"
+#include "ConfigError.hpp"
+
+extern "C" {
+    RayTracer::Core::IEntity* create(const libconfig::Setting &setting) {
+        RayTracer::Shared::Vec3 position;
+        float radius;
+        RayTracer::Shared::Vec3 color;
+
+        if (setting.exists("x") && setting.exists("y") && setting.exists("z")) {
+            int x, y, z;
+            try {
+                x = static_cast<int>(setting.lookup("x"));
+                y = static_cast<int>(setting.lookup("y"));
+                z = static_cast<int>(setting.lookup("z"));
+            } catch (const libconfig::SettingTypeException& ex) {
+                std::cerr << "Error: " << ex.what() << " at " << ex.getPath() << std::endl;
+                throw;
+            }
+
+            position = RayTracer::Shared::Vec3(x, y, z);
+        } else {
+            throw RayTracer::Shared::ConfigError("Cylinder", "Missing position coordinates");
+        }
+
+        if (setting.exists("radius")) {
+            try {
+                radius = static_cast<float>(setting.lookup("radius"));
+            } catch (const libconfig::SettingTypeException& ex) {
+                std::cerr << "Error: " << ex.what() << " at " << ex.getPath() << std::endl;
+                throw;
+            }
+        } else {
+            throw RayTracer::Shared::ConfigError("Cylinder", "Missing radius value");
+        }
+
+        if (setting.exists("color")) {
+            const libconfig::Setting& colorSetting = setting["color"];
+            if (colorSetting.exists("r") && colorSetting.exists("g") && colorSetting.exists("b")) {
+                int r, g, b;
+                try {
+                    r = static_cast<int>(colorSetting.lookup("r"));
+                    g = static_cast<int>(colorSetting.lookup("g"));
+                    b = static_cast<int>(colorSetting.lookup("b"));
+                } catch (const libconfig::SettingTypeException& ex) {
+                    std::cerr << "Error: " << ex.what() << " at " << ex.getPath() << std::endl;
+                    throw;
+                }
+                color = RayTracer::Shared::Vec3(r, g, b);
+            } else {
+                throw RayTracer::Shared::ConfigError("Cylinder", "Missing color values");
+            }
+        } else {
+            throw RayTracer::Shared::ConfigError("Cylinder", "Missing color");
+        }
+
+        return new RayTracer::Plugins::Primitives::Cone(position, radius, color);
+    }
+
+    void destroy(RayTracer::Core::IEntity* cone) {
+        delete cone;
+    }
+
+    const char *getName() {
+        return "Cones";
+    }
+}


### PR DESCRIPTION
Add Cone primitive to the raytracer. Cone is a subclass of APrimitive and implements the scale and intersect methods. Cone is created with a position, radius and color. The intersect method calculates the intersection of a ray with the cone and returns an optional unique_ptr to an Intersection object. The scale method scales the radius of the cone. The Cone class is defined in Cone.hpp and implemented in Cone.cpp. The Cone plugin is created in ConesEntryPoint.cpp and exports the create, destroy and getName functions.